### PR TITLE
style: add padding for mobile view and text center

### DIFF
--- a/src/app/[link]/page.tsx
+++ b/src/app/[link]/page.tsx
@@ -18,7 +18,7 @@ const LinkPage = async ({ params }: LinkPageProps) => {
   return (
     <HydrateClient>
       <main className="mx-auto flex min-h-screen flex-col items-center justify-start gap-8">
-        <div className="flex flex-col items-center justify-center gap-4">
+        <div className="flex flex-col items-center justify-center gap-4 text-center">
           <h1 className="mt-16 flex items-center justify-center gap-2 text-4xl font-bold tracking-tight">
             <span>Safe Transfer</span> <Lock size={36} />
           </h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className={`${GeistSans.variable}`}>
-      <body className="bg-gradient-to-b from-[#fdfbfb] to-[#ebedee] text-slate-800">
+      <body className="bg-gradient-to-b from-[#fdfbfb] to-[#ebedee] px-4 text-slate-800 md:px-0">
         <TRPCReactProvider>
           {children}
           <SiteFooter />


### PR DESCRIPTION
- Added padding (px-4 and md:px-0) to the RootLayout component's <body> tag to improve spacing on mobile devices.
- Centered text in certain sections of the LinkPage component for better readability.